### PR TITLE
Fixing Issue that Allowed Full Game Resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ You can render games in two ways:
    ```
 
 ## Changelog
+## [0.9.8] - 2026-04-17
+
+### Fix
+- Full Game Resets Happening when in Competition Mode
+
+## [0.9.7] - 2026-04-14
+
+### Updated
+- Scoring: Changed level cap from 100% to 115% and Game Cap to weighted average max for the number of levels completed
+
+### Fix
+- Memory Leak Associated With Dynamically Loading Python Game Code
+- Memory Leak Associated With GUID mismatch
+
 ## [0.9.6] - 2026-03-21
 
 ### Fix

--- a/arc_agi/api.py
+++ b/arc_agi/api.py
@@ -293,7 +293,7 @@ class RestAPI:
             guid = data.get("guid")
             if action == GameAction.RESET:
                 if not guid:
-                    guid = str(uuid.uuid4())
+                    guid = game._guid
 
             if not guid:
                 return jsonify(
@@ -320,7 +320,7 @@ class RestAPI:
                         and g._game is not None
                     ):
                         scorecard = self.arcade.scorecard_manager.get_scorecard(
-                            data.get("card_id", None), api_key
+                            data.get("card_id", self.arcade.scorecard_manager.get_scorecard_from_guid(guid).card_id), api_key
                         )
                         # This is quite hacky as we have to look inside the underlying ARCBaseGame
                         # to check if this is the first action of the level and would cause a full reset,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "arc-agi"
-version = "0.9.7"
+version = "0.9.8"
 description = "ARC-AGI Toolkit"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_listen_and_serve.py
+++ b/tests/test_listen_and_serve.py
@@ -598,7 +598,7 @@ class TestListenAndServe(unittest.TestCase):
                 "Four ACTION3 steps should result in levels_completed=1",
             )
 
-            comp_reset_frame = comp_env_1.reset()
+            comp_reset_frame = comp_env_1.step(GameAction.RESET)
             self.assertIsNotNone(comp_reset_frame)
             self.assertEqual(
                 comp_reset_frame.levels_completed,
@@ -607,6 +607,15 @@ class TestListenAndServe(unittest.TestCase):
             )
 
             # a second level reset shouldn't reset the game either
+            comp_reset_frame = comp_env_1.step(GameAction.RESET)
+            self.assertIsNotNone(comp_reset_frame)
+            self.assertEqual(
+                comp_reset_frame.levels_completed,
+                1,
+                "Full reset not have happend and thuse levels_completed should be 1",
+            )
+
+            # a third level reset shouldn't reset the game either, this time via reset()
             comp_reset_frame = comp_env_1.reset()
             self.assertIsNotNone(comp_reset_frame)
             self.assertEqual(
@@ -614,6 +623,14 @@ class TestListenAndServe(unittest.TestCase):
                 1,
                 "Full reset not have happend and thuse levels_completed should be 1",
             )
+            # a fourth level reset shouldn't reset the game either, this time via reset()
+            comp_reset_frame = comp_env_1.reset()
+            self.assertIsNotNone(comp_reset_frame)
+            self.assertEqual(
+                comp_reset_frame.levels_completed,
+                1,
+                "Full reset not have happend and thuse levels_completed should be 1",
+            )            
 
             # No full reset should happen and thus we should have 1 run
             comp_scorecard = client_arc_comp.close_scorecard(scorecard_id=comp_card_id)
@@ -622,8 +639,8 @@ class TestListenAndServe(unittest.TestCase):
             self.assertEqual(len(comp_env_score.runs), 1, "Should have 1 runs")
             self.assertEqual(
                 comp_env_score.runs[0].actions,
-                6,
-                "Should have 6 actions, even the failed reset counts as an action",
+                8,
+                "Should have 8 actions, even the failed reset counts as an action",
             )
 
         finally:

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "arc-agi"
-version = "0.9.7rc1"
+version = "0.9.8"
 source = { editable = "." }
 dependencies = [
     { name = "arcengine" },


### PR DESCRIPTION
Full game resets should not be possible when in competition mode.  However, because a scorecard could not be found (due to both `card_id` not being present and a `guid` mismatch) it was not following the comepetion mode code path.