### PR TITLE
fix: catch UnicodeDecodeError in dotenv loading & update three.arcprize.org URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,5 @@
 
 # define the local server
 # ARC_API_KEY=
-# ARC_BASE_URL=https://three.arcprize.org
+# ARC_BASE_URL=https://arcprize.org
 # OPERATION_MODE=normal

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The `Arcade` constructor accepts the following parameters. All parameters can be
 | Parameter | Type | Default | Environment Variable | Description |
 |-----------|------|---------|---------------------|-------------|
 | `arc_api_key` | `str` | `""` | `ARC_API_KEY` | API key for ARC API. If empty and not in offline mode, an anonymous key will be automatically fetched. |
-| `arc_base_url` | `str` | `"https://three.arcprize.org"` | `ARC_BASE_URL` | Base URL for the ARC API. |
+| `arc_base_url` | `str` | `"https://arcprize.org"` | `ARC_BASE_URL` | Base URL for the ARC API. |
 | `operation_mode` | `OperationMode` | `OperationMode.NORMAL` | `OPERATION_MODE` | `NORMAL` (local + API), `ONLINE` (API only), `OFFLINE` (local only), or `COMPETITON` (API only + [compeition scoring](#competition-mode)). |
 | `environments_dir` | `str` | `"environment_files"` | `ENVIRONMENTS_DIR` | Directory to scan for local `metadata.json` files. |
 | `recordings_dir` | `str` | `"recordings"` | `RECORDINGS_DIR` | Directory to save game recordings (JSONL format). |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ARC-AGI Toolkit is an open-sourced python interface (API) for ARC-AGI-3 interact
    pip install arc-agi
    ```
 
-2. **API Key**: You can optionally set the `ARC_API_KEY` environment variable with your API key. If no key is provided, an anonymous key will be used. However, registering for an API key will give you access to more games at release. [Register for an API key at https://three.arcprize.org](https://three.arcprize.org)
+2. **API Key**: You can optionally set the `ARC_API_KEY` environment variable with your API key. If no key is provided, an anonymous key will be used. However, registering for an API key will give you access to more games at release. [Register for an API key at https://arcprize.org](https://arcprize.org)
    
    The code supports loading from `.env` and `.env.example` files (using python-dotenv), or you can set it directly:
    ```bash

--- a/arc_agi/base.py
+++ b/arc_agi/base.py
@@ -61,7 +61,7 @@ class Arcade:
     def __init__(
         self,
         arc_api_key: str = "",
-        arc_base_url: str = "https://three.arcprize.org",
+        arc_base_url: str = "https://arcprize.org",
         operation_mode: OperationMode = OperationMode.NORMAL,
         environments_dir: str = "environment_files",
         recordings_dir: str = "recordings",

--- a/arc_agi/base.py
+++ b/arc_agi/base.py
@@ -26,13 +26,13 @@ from .wrapper import EnvironmentWrapper
 # Handle missing files and permission errors gracefully
 try:
     load_dotenv(dotenv_path=".env")
-except (OSError, PermissionError, FileNotFoundError):
+except (OSError, PermissionError, FileNotFoundError, UnicodeDecodeError):
     pass
 
 
 try:
     load_dotenv(dotenv_path=".env.example")
-except (OSError, PermissionError, FileNotFoundError):
+except (OSError, PermissionError, FileNotFoundError, UnicodeDecodeError):
     pass
 
 

--- a/arc_agi/base.py
+++ b/arc_agi/base.py
@@ -92,7 +92,7 @@ class Arcade:
             self.arc_api_key = os.getenv("ARC_API_KEY", "")
 
         # arc_base_url: constructor arg > env var > default URL
-        default_base_url = "https://three.arcprize.org"
+        default_base_url = "https://arcprize.org"
         if arc_base_url != default_base_url:
             self.arc_base_url = arc_base_url
         else:

--- a/arc_agi/remote_wrapper.py
+++ b/arc_agi/remote_wrapper.py
@@ -39,7 +39,7 @@ class RemoteEnvironmentWrapper(EnvironmentWrapper):
         """Initialize the remote environment wrapper.
 
         Args:
-            base_url: Base URL for the ARC-AGI-3 API (e.g., "https://three.arcprize.org").
+            base_url: Base URL for the ARC-AGI-3 API (e.g., "https://arcprize.org").
             environment_info: EnvironmentInfo object with game metadata.
             arc_api_key: API key for authentication.
             logger: Logger instance for logging.


### PR DESCRIPTION
## Summary

This PR addresses two issues to improve the SDK and toolchain quality:

### Fix #1: UnicodeDecodeError on import (fixes #17)

When importing `arc_agi`, if a binary file named `.env` exists in the current working directory (e.g., a `.env` directory or binary artifact), `load_dotenv()` raises `UnicodeDecodeError` because it can't decode the file as UTF-8. The existing exception handlers only catch `OSError`, `PermissionError`, and `FileNotFoundError`, missing this case.

**Fix:** Added `UnicodeDecodeError` to both `load_dotenv` exception handlers.

### Fix #2: Update three.arcprize.org references (refs #12)

The old subdomain `three.arcprize.org` has been superseded by `arcprize.org`. Updated all references:

| File | Change |
|------|--------|
| `arc_agi/base.py` | Default `arc_base_url` value |
| `arc_agi/base.py` | `default_base_url` fallback |
| `README.md` | API registration URL and API reference table |
| `.env.example` | Comment with default URL |
| `arc_agi/remote_wrapper.py` | Docstring example URL |

## Testing

- `UnicodeDecodeError`: Verified that `load_dotenv()` correctly catches `UnicodeDecodeError` when a binary `.env` file exists.
- URL updates: Confirmed all `three.arcprize.org` references in the codebase are updated to `arcprize.org`.

## Related Issues
- Closes #17
- Refs #12
